### PR TITLE
added note for UCSM auth domain syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can run the script without arguments; it will ask you for the required input
 * -Username: Username used to login to UCS Manager
 * -Password: Password used to login to UCS Manager
 
+NOTE: If a UCSM authentication domain is used in your environment, the username provided will be "ucs-<AUTHDOMAIN>\<Username>"
+
 ## Multiple UCS Managers
 **OR** you can use a CSV file with the information about multiple UCS Managers. The command looks a bit different in that case:
 


### PR DESCRIPTION
After spending a while to discern this in my environment, I figured it may be convenient to add to the readme.  