### PR TITLE
Two trivial bugs

### DIFF
--- a/UCS-Inventory-Script.ps1
+++ b/UCS-Inventory-Script.ps1
@@ -788,7 +788,7 @@ function GenerateReport()
 
 	# Get all UCS Faults sorted by severity
 	AddToOutput -txt "<h2>Faults</h2>"
-	$Global:TMP_OUTPUT += Get-UcsFault | Sort-Object Sort-Object -Property @{Expression = {$_.Severity}; Ascending = $true}, Created -Descending | Select-Object Severity,Created,Descr,dn | ConvertTo-Html -Fragment
+	$Global:TMP_OUTPUT += Get-UcsFault | Sort-Object -Property @{Expression = {$_.Severity}; Ascending = $true}, Created -Descending | Select-Object Severity,Created,Descr,dn | ConvertTo-Html -Fragment
 
 	AddToOutput -txt "</div>" # end subtab
 	AddToOutput -txt "<div class='content-sub' id='stats-tab-equip'>"

--- a/UCS-Inventory-Script.ps1
+++ b/UCS-Inventory-Script.ps1
@@ -69,8 +69,8 @@ function GenerateReport()
 {
 	Param([Parameter(Mandatory=$true)][string]$UCSM,
 				[Parameter(Mandatory=$true)][string]$OutFile,
-				[Parameter(Mandatory=$true)][string]$Username,
-				[Parameter(Mandatory=$true)][string]$Password,
+				[Parameter(Mandatory=$false)][string]$Username,
+				[Parameter(Mandatory=$false)][string]$Password,
 				[Parameter(Mandatory=$true)][string]$ManualGeneration)
 
 	# Generate credentials


### PR DESCRIPTION
I found two bugs when running the Inventory script.  First, the Username and Password parameters were set to "mandatory" for GenerateReport(), which kept the script from prompting for a username and password if they were not supplied by the user.  Second, there was a simple syntax error when sorting output from Get-UcsFault.

Thanks
Matt